### PR TITLE
Create roundtrip with ELAN annotations

### DIFF
--- a/scripts/add_timed_labels_to_frames.py
+++ b/scripts/add_timed_labels_to_frames.py
@@ -1,0 +1,56 @@
+"""Add label columns to frames for training a multi-hot model.
+
+Usage::
+
+    $ python add_timed_labels_to_frames.py frames-with-scenes.csv <timed-annotations.csv> <output.csv>
+
+"""
+import pandas as pd
+import pandasql as ps
+import sys
+
+
+# Read file names from arguments
+frames_file = sys.argv[1]
+anno_file = sys.argv[2]
+output_file = sys.argv[3]
+
+# Load frames data
+csv_dtypes = {
+    "frame": "int64",
+    "scene": "int64",
+    "pkt_pts_time": "float64"
+}
+use_cols = ["frame","pkt_pts_time","scene"]
+frames_data = pd.read_csv(frames_file, dtype = csv_dtypes, index_col="frame", usecols=use_cols)
+print(frames_data.head())
+
+
+# Add column for frame filename
+def derive_filename(row):
+    frame_nr = str(row.name).rjust(6, "0")
+    filename = f'{frame_nr[:2]}/{frame_nr[2:4]}/f-{frame_nr}.jpg'
+    return filename
+
+frames_data.loc[:, 'filename'] = frames_data.apply(derive_filename, axis=1)
+
+# Load scene data
+anno_data = pd.read_csv(anno_file, usecols=lambda x: not x.startswith("Unnamed"))
+anno_data.rename({"Begin Time - ss.msec": "anno_start", "End Time - ss.msec": "anno_end"}, axis="columns", inplace=True)
+print(anno_data.head())
+
+# Join the scene labels with the original frame list
+join_query = '''
+select *
+from frames_data f 
+left join anno_data a
+on f.pkt_pts_time >= a.anno_start and f.pkt_pts_time < a.anno_end
+'''
+
+frames_with_labels = ps.sqldf(join_query, locals()).set_index("frame")
+frames_with_labels.loc[frames_with_labels["pentagram"].notna(), "pentagram_visible"] = 1.0
+frames_with_labels.loc[frames_with_labels["star"].notna(), "star_visible"] = 1.0
+print(frames_with_labels.head())
+frames_with_labels.to_csv(output_file)
+
+

--- a/scripts/mark_from_predictions.py
+++ b/scripts/mark_from_predictions.py
@@ -1,0 +1,74 @@
+"""
+Create timespan annotations from predictions for use in ELAN.
+
+Usage::
+
+    $ python mark_from_predictions.py frame-predictions.csv prediction-elan.csv
+
+"""
+import pandas as pd
+import sys
+
+COLUMN_SUFFIX = "_pred"
+
+# Read file name from arguments and load
+predictions_file = sys.argv[1]
+csv_dtypes = {
+    "frame": "int64",
+    "pkt_pts_time": "float64",
+    "lavfi_scd_mafd": "float64",
+    "lavfi_scd_score": "float64",
+    "lavfi_scd_time": "float64"
+}
+# use_cols = ["frame","pkt_pts_time","lavfi_scd_mafd","lavfi_scd_score","lavfi_scd_time","lavfi_blackframe_pblack"]
+frames_data = pd.read_csv(predictions_file, dtype = csv_dtypes)
+# frames_data = pd.read_csv(predictions_file, dtype = csv_dtypes, index_col="frame")
+
+label_columns = [col_name for col_name in frames_data.columns if col_name.endswith(COLUMN_SUFFIX)]
+print(f'Found {label_columns} as columns with predictions.')
+print(frames_data.head())
+# Make sure the first frame starts an annotation by setting the `anno_bound`
+frames_data.loc[0, "anno_bound"] = 0.0
+
+# Start annotation when predicted probability changes from < 0.5 to > 0.5
+frames_data.loc[:, "penta_change"] = frames_data["pentagram_pred_round"].rolling(3, min_periods=2, center=False).sum()
+frames_data.loc[frames_data.penta_change == 1.0, "anno_bound"] = frames_data.pkt_pts_time
+
+# Fill down the annotation boundary time to allow grouping frames by annotation
+frames_data["anno_bound"].fillna(method="pad", inplace=True)
+
+anno_groups = frames_data.groupby("anno_bound")
+anno_numbers = anno_groups.ngroup()
+positive_annos = anno_groups["penta_change"].sum()
+print(anno_numbers.head())
+print(positive_annos.head())
+
+# Join the annotation indices with the original frame list
+frames_with_annos = frames_data.assign(anno=anno_numbers).join(positive_annos, on="anno_bound", lsuffix="_l", rsuffix="_r")
+print(frames_with_annos.head())
+
+enriched_file = sys.argv[2]
+frames_with_annos.to_csv(enriched_file)
+
+# Determine length of annotations
+anno_sizes = anno_groups.size()
+print(anno_sizes.head())
+
+frame_duration = frames_data.loc[1, "pkt_pts_time"]
+
+annos = anno_groups.agg(
+    last_pts=("pkt_pts_time", "max"),
+    duration=("pkt_pts_time", lambda x: round(x.max() - x.min(), 5)),
+    first_frame=("frame", "min"),
+    last_frame=("frame", "max")
+    )\
+    .assign(number_of_frames=anno_sizes, change_sum=positive_annos)\
+    .reset_index()
+annos.index.name = "anno"
+print(annos.head())
+
+# Save the annotations information to a new file based on the input file name
+analysed_file = enriched_file.replace(".csv", "-annos.csv")
+if len(sys.argv) > 3:
+    analysed_file = sys.argv[3]
+annos.query("change_sum > 1.0 & number_of_frames > 25").to_csv(analysed_file)

--- a/scripts/mark_from_predictions.py
+++ b/scripts/mark_from_predictions.py
@@ -24,51 +24,67 @@ csv_dtypes = {
 frames_data = pd.read_csv(predictions_file, dtype = csv_dtypes)
 # frames_data = pd.read_csv(predictions_file, dtype = csv_dtypes, index_col="frame")
 
+frame_duration = frames_data.loc[1, "pkt_pts_time"]
+
 label_columns = [col_name for col_name in frames_data.columns if col_name.endswith(COLUMN_SUFFIX)]
 print(f'Found {label_columns} as columns with predictions.')
 print(frames_data.head())
-# Make sure the first frame starts an annotation by setting the `anno_bound`
-frames_data.loc[0, "anno_bound"] = 0.0
-
-# Start annotation when predicted probability changes from < 0.5 to > 0.5
-frames_data.loc[:, "penta_change"] = frames_data["pentagram_pred_round"].rolling(3, min_periods=2, center=False).sum()
-frames_data.loc[frames_data.penta_change == 1.0, "anno_bound"] = frames_data.pkt_pts_time
-
-# Fill down the annotation boundary time to allow grouping frames by annotation
-frames_data["anno_bound"].fillna(method="pad", inplace=True)
-
-anno_groups = frames_data.groupby("anno_bound")
-anno_numbers = anno_groups.ngroup()
-positive_annos = anno_groups["penta_change"].sum()
-print(anno_numbers.head())
-print(positive_annos.head())
-
-# Join the annotation indices with the original frame list
-frames_with_annos = frames_data.assign(anno=anno_numbers).join(positive_annos, on="anno_bound", lsuffix="_l", rsuffix="_r")
-print(frames_with_annos.head())
 
 enriched_file = sys.argv[2]
-frames_with_annos.to_csv(enriched_file)
+all_anno_frames = []
 
-# Determine length of annotations
-anno_sizes = anno_groups.size()
-print(anno_sizes.head())
+for label in label_columns:
+    col_rounded = label + "_round"
+    stem = label[:-len(COLUMN_SUFFIX)]
+    anno_bound = stem + "_start"
+    change = stem + "_change"
 
-frame_duration = frames_data.loc[1, "pkt_pts_time"]
+    # Make sure the first frame starts an annotation by setting the `anno_bound`
+    frames_data.loc[0, anno_bound] = 0.0
 
-annos = anno_groups.agg(
-    last_pts=("pkt_pts_time", "max"),
-    duration=("pkt_pts_time", lambda x: round(x.max() - x.min(), 5)),
-    first_frame=("frame", "min"),
-    last_frame=("frame", "max")
-    )\
-    .assign(number_of_frames=anno_sizes, change_sum=positive_annos)\
-    .reset_index()
-annos.index.name = "anno"
-print(annos.head())
+    # Start annotation when predicted probability changes from < 0.5 to > 0.5
+    # We use the rounded probability for this
+    frames_data.loc[:, change] = frames_data[col_rounded].rolling(2, min_periods=2, center=False).sum()
+    frames_data.loc[frames_data[change] == 1.0, anno_bound] = frames_data.pkt_pts_time
+
+    # Fill down the annotation boundary time to allow grouping frames by annotation
+    frames_data[anno_bound].fillna(method="pad", inplace=True)
+
+    anno_groups = frames_data.groupby(anno_bound)
+    anno_numbers = anno_groups.ngroup()
+    positive_annos = anno_groups[change].sum()
+    print(anno_numbers.head())
+    print(positive_annos.head())
+
+    # Join the annotation indices with the original frame list
+    frames_data = frames_data.assign(**{stem+"_anno": anno_numbers})
+    print(frames_data.head())
+
+    # Determine length of annotations
+    anno_sizes = anno_groups.size()
+    print(anno_sizes.head())
+
+    annos = anno_groups.agg(
+        last_pts=("pkt_pts_time", "max"),
+        duration=("pkt_pts_time", lambda x: round(x.max() - x.min() + frame_duration, 5)),
+        first_frame=("frame", "min"),
+        last_frame=("frame", "max")
+        )\
+        .assign(number_of_frames=anno_sizes, change_sum=positive_annos, symbol=stem)\
+        .reset_index()
+    annos.index.name = "anno"
+    annos.rename({anno_bound: "anno_start"}, axis="columns", inplace=True)
+    print(annos.head())
+
+    all_anno_frames.append(annos)
 
 # Save the annotations information to a new file based on the input file name
 analysed_file = enriched_file.replace(".csv", "-annos.csv")
 if len(sys.argv) > 3:
     analysed_file = sys.argv[3]
-annos.query("change_sum > 1.0 & number_of_frames > 25").to_csv(analysed_file)
+
+all_annos = pd.concat(all_anno_frames, ignore_index=True)
+all_annos.index.name = "anno_id"
+all_annos.query("change_sum > 1.0 & number_of_frames > 25").to_csv(analysed_file)
+
+frames_data.to_csv(enriched_file)


### PR DESCRIPTION
Two additional scripts allow to create a file for import into ELAN and merge ELAN-created annotations with the list of frames for (re)training.

This closes #4.