### PR TITLE
Use newly published UB Leiden MkDocs theme

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,11 +2,13 @@ site_name: MIDA Video Pre-analysis Tools
 # site_url: 'https://lab.library.universiteitleiden.nl/'
 remote_branch: rendered
 theme:
-  name: material
-  font: false
+  name: ubleiden
+  # font: false
   # favicon: 'favicon.ico'
   language: en
   # custom_dir: leiden_theme
+  features:
+    - navigation.sections
 
 # extra_css:
   # - 'css/extra.css'
@@ -25,9 +27,10 @@ markdown_extensions:
   - footnotes
 
 nav:
-  - 'index.md'
-  - 'scene-detect.md'
-  - 'ocr.md'
-  - 'annotation.md'
-  - 'extract-frames.md'
+  - Overview: 'index.md'
+  - Pre-analysis steps:
+    - 'scene-detect.md'
+    - 'ocr.md'
+    - 'annotation.md'
+    - 'extract-frames.md'
   - deprecated.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+mkdocs-ubleiden-theme>=1.0


### PR DESCRIPTION
Require the [`mkdocs-ubleiden-theme`](https://pypi.org/project/mkdocs-ubleiden-theme/) to be installed, and use it in the mkdocs.yml configuration.

Not really related, but closes #3 